### PR TITLE
Small fixes to the test scripts

### DIFF
--- a/testcases/monitor_testcase_15.sh
+++ b/testcases/monitor_testcase_15.sh
@@ -40,7 +40,7 @@ for dasd in $(mdadm --detail ${MD_DEV} | sed -n 's/.*set-A failfast *\/dev\/\(.*
 done
 num=0
 for dasd in ${DASDS_LEFT[@]}  ; do
-    devno=$(lsdasd | sed -n "/$dasd/p" | cut -f 1 -d ' ')
+    devno=$(lsdasd | sed -n "/[[:space:]]$dasd[[:space:]]/p" | cut -f 1 -d ' ')
     echo "$(date) Reserve DASD $devno on left half ..."
     result=$(run_wget ${devno} online)
     if [ "$result" ] ; then
@@ -112,7 +112,7 @@ echo "$(date) Wait for $IO_TIMEOUT seconds"
 sleep $IO_TIMEOUT
 
 for dasd in ${DASDS_LEFT[@]}  ; do
-    devno=$(lsdasd | sed -n "/$dasd/p" | cut -f 1 -d ' ')
+    devno=$(lsdasd | sed -n "/[[:space:]]$dasd[[:space:]]/p" | cut -f 1 -d ' ')
     echo "$(date) Release DASD $devno on left half ..."
     result=$(run_wget ${devno} Release)
     if [ "$result" ] ; then

--- a/testcases/monitor_testcase_5.sh
+++ b/testcases/monitor_testcase_5.sh
@@ -11,8 +11,8 @@ MD_NUM="md1"
 MD_NAME="testcase5"
 MONITOR_TIMEOUT=60
 
-CHPID_LEFT="0.4b"
-CHPID_RIGHT="0.4e"
+CHPID_LEFT="0.13"
+CHPID_RIGHT="0.1b"
 
 detach_other_half=1
 


### PR DESCRIPTION
The CHP ID changes originated from the setup adjustments during migration to the new host.  The bug in testcase 15 was discovered during testing.