### PR TITLE
md_monitor: Ignore NewArray message if it doesn't exist yet

### DIFF
--- a/md_monitor.c
+++ b/md_monitor.c
@@ -2436,7 +2436,7 @@ void *cli_monitor_thread(void *ctx)
 		     event, mdstr, devstr ? devstr : "<NULL>");
 
 		md_dev = lookup_md_alias(mdstr);
-		if (!md_dev) {
+		if (!md_dev && strcmp(event, "NewArray")) {
 			info("%s: skipping event, array not monitored", mdstr);
 			buf[0] = ENODEV;
 			iov.iov_len = 1;


### PR DESCRIPTION
Due to a race between the uevent and mdadm creating the device
it might be that md_monitor can receive the 'NewArray' message,
 but hasn't been able to process the information for that new array.
Hence this message can safely be ignored.