### PR TITLE
md_monitor: display_md_status: don't omit trailing dots (bsc#1140006)

### DIFF
--- a/md_monitor.c
+++ b/md_monitor.c
@@ -2026,6 +2026,8 @@ static int display_md_status(struct md_monitor *md_dev, char *buf, int buflen)
 	}
 	pthread_mutex_unlock(&md_dev->device_lock);
 	max_slot++;
+	if (md_dev->raid_disks < buflen && md_dev->raid_disks > max_slot)
+		max_slot = md_dev->raid_disks;
 	if (max_slot >= buflen) {
 		warn("%s: CLI buffer too small, min %d\n",
 		     md_dev->dev_name, max_slot);
@@ -2068,6 +2070,8 @@ static int display_io_status(struct md_monitor *md_dev, char *buf, int buflen)
 	pthread_mutex_unlock(&md_dev->device_lock);
 
 	max_slot++;
+	if (md_dev->raid_disks < buflen && md_dev->raid_disks > max_slot)
+		max_slot = md_dev->raid_disks;
 	if (max_slot >= buflen) {
 		warn("%s: CLI buffer too small, min %d",
 		     md_dev->dev_name, max_slot);


### PR DESCRIPTION
display_md_status() and display_io_status() end
output at the index of the last child of the md array they encounter
while walking the sibling list. This may lead to missing trailing dots (".")
if a disk at the end of the array was in removed.

This behavior was introduced by the past commits mentioned below,
with the intention to fix a crash that occured when a degraded
md_monitor struct (with md_dev->raid_disks == -1) was encountered.
Fix this case by using md_dev->raid_disks again if it is larger
than the last slot encountered.

Fixes: 2379a9c md_monitor: fixup crash in display_io_status
Dixes: 62d385b md_monitor: fixup crash in display_md_status