### PR TITLE
Make: change installation destination of sysconfig.md_monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install: all
 	install -D -m 644 md_monitor.man $(DESTDIR)$(MAN8DIR)/md_monitor.8
 	install -D -m 644 setdasd.man $(DESTDIR)$(MAN8DIR)/setdasd.8
 	install -D -m 644 md_monitor.service $(DESTDIR)/usr/lib/systemd/system/md_monitor.service
-	install -D -m 644 sysconfig.md_monitor $(DESTDIR)/var/adm/fillup-templates/sysconfig.md_monitor
+	install -D -m 644 sysconfig.md_monitor $(DESTDIR)/usr/share/fillup-templates/sysconfig.md_monitor
 
 md_monitor: md_monitor.o dasd_ioctl.o dasd_util.o mpath_util.c
 	$(CC) $(CFLAGS) -o $@ $^ -ludev -lpthread -laio


### PR DESCRIPTION
Default templates directory is changed from /var/adm/fillup-templates
to /usr/share/fillup-templates in November 2017. This patch changes
installation destination of sysconfig.md_monitor to the new templates
directory.

Signed-off-by: Coly Li <colyli@suse.de>