### PR TITLE
md_monitor: replace pselect with ppoll

### DIFF
--- a/md_monitor.c
+++ b/md_monitor.c
@@ -2965,7 +2965,7 @@ int main(int argc, char *argv[])
 	struct rlimit cur;
 	char *command_to_send = NULL;
 	char *logfile = NULL;
-	fd_set readfds;
+	struct pollfd readfd;
 	int monitor_fd;
 	int rc = 0;
 
@@ -3249,12 +3249,12 @@ int main(int argc, char *argv[])
 		int fdcount;
 		struct timespec tmo;
 
-		FD_ZERO(&readfds);
-		FD_SET(monitor_fd, &readfds);
+		readfd.fd = monitor_fd;
+		readfd.events = POLLIN;
 		tmo.tv_sec = 1;
 		tmo.tv_nsec = 0;
-		fdcount = pselect(monitor_fd + 1, &readfds,
-				  NULL, NULL, &tmo, &thread_sigmask);
+		fdcount = ppoll(&readfd, 1, &tmo, &thread_sigmask);
+
 		if (fdcount < 0) {
 			if (errno != EINTR)
 				warn("error receiving uevent message: %m");
@@ -3264,7 +3264,7 @@ int main(int argc, char *argv[])
 		if (fdcount == 0)
 			continue;
 
-		if (FD_ISSET(monitor_fd, &readfds)) {
+		if (readfd.revents & POLLIN) {
 			struct udev_device *device;
 
 			device = udev_monitor_receive_device(udev_monitor);


### PR DESCRIPTION
File descriptor number assigned to monitor_fd depends on number of
monitored devices and might be greater than FD_SETSIZE.
In such cases it causes array overflow and crash when passed to pselect().
Using ppoll() instead of pselect() fixes the issue.

References: bsc#1161872