### PR TITLE
md_monitor: remove the obsolete md_dev from md_list

### DIFF
--- a/md_monitor.c
+++ b/md_monitor.c
@@ -2029,10 +2029,15 @@ static void discover_md(struct udev *udev)
 		md_dev = udev_device_new_from_syspath(udev, md_devpath);
 		warn("Testing %s", md_devpath);
 		if (md_dev) {
-			monitor_md(md_dev);
+			if (monitor_md(md_dev) != 0) {
+				md_devpath = udev_device_get_sysname(md_dev);
+				unmonitor_md(md_devpath);
+				goto unref;
+            }
 			udev_device_unref(md_dev);
 		}
 	}
+unref:
 	udev_enumerate_unref(md_enumerate);
 }
 


### PR DESCRIPTION
There is a race condition between md device was shutting down and
md_monitor was started. md_monitor() function might failed during this
process, thus an obsolete md_dev was linked to md_list. Even though the
md device was reassembled, the attributes generated from CHANGE event
can't be obtained. So md_monitor would report the md device doesn't
exist when searching with md_name.

References: bsc#1193465
Signed-off-by: Lidong Zhong <lidong.zhong@suse.com>