### PR TITLE
md_monitor: fix deadlock because of locking itself

### DIFF
--- a/md_monitor.c
+++ b/md_monitor.c
@@ -743,7 +743,6 @@ static void md_rdev_update_index(struct md_monitor *md,
 				dev->md_side = dev->md_slot % (md->layout & 0xFF);
 			info("%s: update index on %s (%d/%d)", md->dev_name,
 			     dev->md_name, dev->md_index, dev->md_slot);
-			monitor_device(dev);
 			break;
 		}
 	}


### PR DESCRIPTION
The call stack is shown below:

 Core was generated by `/sbin/md_monitor'.
  #0  0x000003ff83a1243c in __lll_lock_wait () from
 ./lib64/libpthread.so.0 [Current thread is 1 (Thread 0x3ff83bf4810 (LWP
             3362))] #where
  #0  0x000003ff83a1243c in __lll_lock_wait () from
 ./lib64/libpthread.so.0
  #1  0x000003ff83a0c8ba in pthread_mutex_lock () from
 ./lib64/libpthread.so.0
  #2  0x000000000100606c in device_monitor_get (dev=0x227606a0) at
 md_monitor.c:439
  #3  monitor_device (dev=0x227606a0) at md_monitor.c:1154
  #4  0x00000000010067e2 in md_rdev_update_index
 (md=md@entry=0x2275a390, dev=dev@entry=0x227606a0) at md_monitor.c:746
  #5  0x00000000010069ba in add_component (md=0x2275a390,
          dev=0x227606a0, md_name=0x2275ad50 "dasdfl1") at
  md_monitor.c:1220
  #6  0x0000000001007564 in attach_device (udev_dev=<error reading
        variable: value has been optimized out>) at md_monitor.c:601
  #7  0x000000000100526a in handle_event (device=<optimized out>) at
  md_monitor.c:2216
  #8  main (argc=<optimized out>, argv=<optimized out>) at
   md_monitor.c:3274 =====/

dev->lock is already held before calling md_rdev_update_index() in
add_component(). It will lock up itself when trying to get the
dev->lock in monitor_device(). Since monitor_device() will be called after
function add_component(), so removing monitor_device() in
md_rdev_update_index().

Reference: bsc#1197160