### PR TITLE
monitor: md_monitor skips the other md devices when an obsolete one is discovered

### DIFF
--- a/md_monitor.c
+++ b/md_monitor.c
@@ -2031,12 +2031,12 @@ static void discover_md(struct udev *udev)
 			if (monitor_md(md_dev) != 0) {
 				md_devpath = udev_device_get_sysname(md_dev);
 				unmonitor_md(md_devpath);
-				goto unref;
+				/* udev_device_unref() is already called in unmonitor_md() */
+				continue;
             }
 			udev_device_unref(md_dev);
 		}
 	}
-unref:
 	udev_enumerate_unref(md_enumerate);
 }
 


### PR DESCRIPTION
We tried to remove an obsolete md device in the following patch
commit 22922c4239f7850a871b7d62c98becad90076b45
Author: Lidong Zhong <lidong.zhong@suse.com>
Date:   Tue Dec 28 15:29:29 2021 +0800

    md_monitor: remove the obsolete md_dev from md_list

but it will skip the other md devices to monitor.

References: bsc#1193465
Fixes: 22922c4239f7 (md_monitor: remove the obsolete md_dev from md_list)